### PR TITLE
feat(petition-component): sf-only mode

### DIFF
--- a/apps/freezoe.org/src/app/petition.tsx
+++ b/apps/freezoe.org/src/app/petition.tsx
@@ -22,6 +22,7 @@ export function Petition() {
       petitionId={process.env.NEXT_PUBLIC_PETITION_ID!}
       campaignName={process.env.NEXT_PUBLIC_CAMPAIGN_NAME!}
       defaultMessage={DEFAULT_MESSAGE}
+      locationInputMode="zipWithSonomaCountyCity"
       onSubmit={onSubmit}
       debug={searchParams.get("debug") === "true"}
       test={searchParams.get("test") === "true"}

--- a/apps/helpthechickens.com/src/app/petition.tsx
+++ b/apps/helpthechickens.com/src/app/petition.tsx
@@ -22,6 +22,7 @@ export function Petition() {
       petitionId={process.env.NEXT_PUBLIC_PETITION_ID!}
       campaignName={process.env.NEXT_PUBLIC_CAMPAIGN_NAME!}
       defaultMessage={DEFAULT_MESSAGE}
+      locationInputMode="zipWithSonomaCountyCity"
       onSubmit={onSubmit}
       debug={searchParams.get("debug") === "true"}
       test={searchParams.get("test") === "true"}

--- a/apps/helptheducks.com/src/app/petition.tsx
+++ b/apps/helptheducks.com/src/app/petition.tsx
@@ -22,6 +22,7 @@ export function Petition() {
       petitionId={process.env.NEXT_PUBLIC_PETITION_ID!}
       campaignName={process.env.NEXT_PUBLIC_CAMPAIGN_NAME!}
       defaultMessage={DEFAULT_MESSAGE}
+      locationInputMode="zipWithSonomaCountyCity"
       onSubmit={onSubmit}
       debug={searchParams.get("debug") === "true"}
       test={searchParams.get("test") === "true"}

--- a/packages/email-petition-element/README.md
+++ b/packages/email-petition-element/README.md
@@ -23,9 +23,10 @@ There are two ways to preview the component, and they test different things.
 pnpm serve
 ```
 
-This starts Vite (with `--host`) and serves the example `index.html`, which loads
-the component's **source** (`/src/index.tsx`) as native ES modules with hot
-reloading. Use this for fast iteration on the component itself.
+This starts Vite (with `--host`) and opens the example page from `dev-preview/`
+(served at `/`), which loads the component's **source** (`src/index.tsx`) as
+native ES modules with hot reloading. Use this for fast iteration on the
+component itself.
 
 In VS Code you can launch the same thing from the **Run and Debug** panel with the
 **"Dev email petition element preview - fast reload"** configuration, which runs
@@ -47,9 +48,6 @@ HTTP server (no Vite, no module layer). Open <http://localhost:4173/> — it loa
 built `email-petition.js` via a plain `<script src>`, exactly the way a third-party
 site embeds it. This is the faithful way to catch bugs that only appear in the shipped
 IIFE before they reach production.
-
-Only `build-preview/` is served, so the source `index.html` and `/src` are not
-reachable — the page behaves like an isolated third-party host.
 
 In VS Code you can launch this from the **Run and Debug** panel with the
 **"Dev email petition element preview - build artifact"** configuration.

--- a/packages/email-petition-element/README.md
+++ b/packages/email-petition-element/README.md
@@ -63,6 +63,7 @@ In VS Code you can launch this from the **Run and Debug** panel with the
   petition-id="your-petition-id"
   campaign-name="your-campaign-name"
   default-message="Dear Decision Maker,&#10;&#10;I urge you to take action.&#10;&#10;[Your name], [Your city]"
+  location-input-mode="zipWithSonomaCountyCity"
 ></email-petition>
 ```
 
@@ -73,6 +74,7 @@ In VS Code you can launch this from the **Run and Debug** panel with the
   petition-id="your-petition-id"
   campaign-name="your-campaign-name"
   default-message="Dear Decision Maker, ..."
+  location-input-mode="zipWithSonomaCountyCity"
   thermometer-goal="1000"
 ></email-petition>
 ```
@@ -86,6 +88,7 @@ Use `test` to prefix IDs with `test:` so submissions don't affect production dat
   petition-id="my-petition"
   campaign-name="my-campaign"
   default-message="..."
+  location-input-mode="zipWithSonomaCountyCity"
   test
   debug
 ></email-petition>
@@ -93,14 +96,34 @@ Use `test` to prefix IDs with `test:` so submissions don't affect production dat
 
 ## Attribute reference
 
-| Attribute          | Type    | Required | Description                                                                    |
-| ------------------ | ------- | -------- | ------------------------------------------------------------------------------ |
-| `petition-id`      | string  | yes      | ID passed to the petition signing API                                          |
-| `campaign-name`    | string  | yes      | Campaign name passed to the mailer API                                         |
-| `default-message`  | string  | yes      | Pre-filled message body; supports `[Your name]` and `[Your city]` placeholders |
-| `thermometer-goal` | number  | no       | Shows a signature thermometer with this goal count                             |
-| `test`             | boolean | no       | Prefixes IDs with `test:` to avoid polluting production data                   |
-| `debug`            | boolean | no       | Logs resolved API URLs and IDs to the console                                  |
+| Attribute             | Type    | Required | Description                                                                       |
+| --------------------- | ------- | -------- | --------------------------------------------------------------------------------- |
+| `petition-id`         | string  | yes      | ID passed to the petition signing API                                             |
+| `campaign-name`       | string  | yes      | Campaign name passed to the mailer API                                            |
+| `default-message`     | string  | yes      | Pre-filled message body; supports `[Your name]` and `[Your city]` placeholders    |
+| `location-input-mode` | string  | yes      | Which location fields to collect. `zipWithSonomaCountyCity` or `sfOnly`            |
+| `thermometer-goal`    | number  | no       | Shows a signature thermometer with this goal count                                |
+| `test`                | boolean | no       | Prefixes IDs with `test:` to avoid polluting production data                      |
+| `debug`               | boolean | no       | Logs resolved API URLs and IDs to the console                                     |
+
+### Location input modes
+
+The `location-input-mode` attribute is required and controls how a signer's
+location is collected:
+
+- `zipWithSonomaCountyCity`: a US zip code field, an auto-derived city
+  selector for Sonoma County zips, and an "Outside the United States" toggle.
+- `sfOnly`: hides zip and city and instead shows a required "I am a resident of
+  San Francisco, CA" checkbox. Submissions are tagged with San Francisco, CA, US.
+
+```html
+<email-petition
+  petition-id="your-petition-id"
+  campaign-name="your-campaign-name"
+  default-message="..."
+  location-input-mode="sfOnly"
+></email-petition>
+```
 
 ## Notes
 

--- a/packages/email-petition-element/dev-preview/index.html
+++ b/packages/email-petition-element/dev-preview/index.html
@@ -23,6 +23,8 @@
       debug="true"
       thermometer-goal="1000"
     ></email-petition>
-    <script type="module" src="/src/index.tsx"></script>
+    <script type="module">
+      import "@src/index.tsx";
+    </script>
   </body>
 </html>

--- a/packages/email-petition-element/dev-preview/index.html
+++ b/packages/email-petition-element/dev-preview/index.html
@@ -19,6 +19,7 @@
       petition-id="-1"
       campaign-name="Test Campaign"
       default-message="I'm writing to urge you to take action on this important issue."
+      location-input-mode="zipWithSonomaCountyCity"
       test="true"
       debug="true"
       thermometer-goal="1000"

--- a/packages/email-petition-element/dev-preview/sf-only.html
+++ b/packages/email-petition-element/dev-preview/sf-only.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>email-petition preview (built artifact)</title>
+    <title>email-petition demo</title>
     <style>
       body {
         font-family: sans-serif;
@@ -14,22 +14,18 @@
     </style>
   </head>
   <body>
-    <h2>email-petition element — built-artifact preview</h2>
-    <p>
-      This page loads the bundled <code>email-petition.js</code> via a plain
-      <code>&lt;script src&gt;</code>, exactly the way a third-party site does —
-      no Vite, no module layer. Use it to catch bugs that only appear in the
-      shipped IIFE (e.g. undefined globals like <code>process</code>).
-    </p>
+    <h2>email-petition element — dev demo</h2>
     <email-petition
       petition-id="-1"
       campaign-name="Test Campaign"
       default-message="I'm writing to urge you to take action on this important issue."
-      location-input-mode="zipWithSonomaCountyCity"
+      location-input-mode="sfOnly"
       test="true"
       debug="true"
       thermometer-goal="1000"
     ></email-petition>
-    <script src="/email-petition.js"></script>
+    <script type="module">
+      import "@src/index.tsx";
+    </script>
   </body>
 </html>

--- a/packages/email-petition-element/src/index.tsx
+++ b/packages/email-petition-element/src/index.tsx
@@ -1,6 +1,7 @@
 import styles from "./styles.css?inline";
 import r2wc from "@r2wc/react-to-web-component";
 import { EmailPetition } from "@dxe/email-petition/email-petition";
+import type { LocationInputMode } from "@dxe/email-petition/email-petition";
 
 /**
  * Tailwind v4 implements many utilities (borders, rings, shadows, transforms,
@@ -42,6 +43,7 @@ function EmailPetitionWrapper(props: {
   petitionId: string;
   campaignName: string;
   defaultMessage: string;
+  locationInputMode: LocationInputMode;
   debug?: boolean;
   test?: boolean;
   thermometerGoal?: number;
@@ -50,6 +52,7 @@ function EmailPetitionWrapper(props: {
     "petition-id": props.petitionId,
     "campaign-name": props.campaignName,
     "default-message": props.defaultMessage,
+    "location-input-mode": props.locationInputMode,
   };
   for (const [attribute, value] of Object.entries(required)) {
     if (!value) {
@@ -68,6 +71,7 @@ function EmailPetitionWrapper(props: {
         petitionId={props.petitionId}
         campaignName={props.campaignName}
         defaultMessage={props.defaultMessage}
+        locationInputMode={props.locationInputMode}
         debug={props.debug ?? false}
         test={props.test ?? false}
         signatureThermometer={
@@ -86,6 +90,7 @@ const EmailPetitionElement = r2wc(EmailPetitionWrapper, {
     petitionId: "string",
     campaignName: "string",
     defaultMessage: "string",
+    locationInputMode: "string",
     debug: "boolean",
     test: "boolean",
     thermometerGoal: "number",

--- a/packages/email-petition-element/vite.config.ts
+++ b/packages/email-petition-element/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
@@ -36,7 +37,19 @@ export default defineConfig(({ mode }) => {
       ),
     },
     ...(isDev
-      ? {}
+      ? {
+          // Serve the dev demo page (dev-preview/index.html) at `/`.
+          //
+          // Because the dev root is dev-preview/, the page can't reach the
+          // component source with a relative path (it'd be clamped at the root),
+          // so it imports `@src/index.tsx` and we alias `@src` back to ../src.
+          root: "dev-preview",
+          resolve: {
+            alias: {
+              "@src": fileURLToPath(new URL("./src", import.meta.url)),
+            },
+          },
+        }
       : {
           build: {
             lib: {

--- a/packages/email-petition/src/data/petition.ts
+++ b/packages/email-petition/src/data/petition.ts
@@ -3,46 +3,76 @@ import { SonomaCities } from "./zipcodes";
 
 const EmptyStringToUndefined = z.literal("").transform(() => undefined);
 
-export const PetitionFormSchema = z
-  .object({
-    name: z
-      .string()
-      .min(2, { message: "Name too short" })
-      .max(255, { message: "Name too long" }),
-    email: z.string().email().max(255, { message: "Email too long" }),
-    phone: z
-      .string()
-      .regex(/^[0-9+-]*$/, {
-        message: "Phone number may only contain numbers, +, and -",
-      })
-      .min(10, { message: "Phone number too short" })
-      .max(255, { message: "Phone number too long" })
-      .or(EmptyStringToUndefined)
-      .optional(),
-    outsideUS: z.boolean(),
-    zip: z
-      .string()
-      .regex(/^[0-9]*$/, {
-        message:
-          "Zip code must only contain numbers, or be empty if 'Outside the United States' is checked.",
-      })
-      .length(5, {
-        message:
-          "Zip code must be 5 digits, or empty if 'Outside the United States' is checked.",
-      })
-      .or(EmptyStringToUndefined)
-      .optional(),
-    city: z
-      .string()
-      .max(255, { message: "City too long" })
-      .or(EmptyStringToUndefined)
-      .optional(),
-    message: z
-      .string()
-      .min(10, { message: "Message must be at least 10 characters" })
-      .max(10_000, { message: "Please limit message to 10,000 characters" }),
-  })
-  .superRefine((data, ctx) => {
+/**
+ * Controls which location fields the petition form collects.
+ *
+ * - `zipWithSonomaCountyCity`: zip code (US only) plus an auto-derived city
+ *   selector for Sonoma County zips, and an "Outside the United States" toggle.
+ * - `sfOnly`: hides zip and city entirely and instead requires the signer to
+ *   confirm they are a resident of San Francisco, CA.
+ */
+export const LOCATION_INPUT_MODES = [
+  "zipWithSonomaCountyCity",
+  "sfOnly",
+] as const;
+
+export type LocationInputMode = (typeof LOCATION_INPUT_MODES)[number];
+
+const PetitionFormObject = z.object({
+  name: z
+    .string()
+    .min(2, { message: "Name too short" })
+    .max(255, { message: "Name too long" }),
+  email: z.string().email().max(255, { message: "Email too long" }),
+  phone: z
+    .string()
+    .regex(/^[0-9+-]*$/, {
+      message: "Phone number may only contain numbers, +, and -",
+    })
+    .min(10, { message: "Phone number too short" })
+    .max(255, { message: "Phone number too long" })
+    .or(EmptyStringToUndefined)
+    .optional(),
+  outsideUS: z.boolean(),
+  zip: z
+    .string()
+    .regex(/^[0-9]*$/, {
+      message:
+        "Zip code must only contain numbers, or be empty if 'Outside the United States' is checked.",
+    })
+    .length(5, {
+      message:
+        "Zip code must be 5 digits, or empty if 'Outside the United States' is checked.",
+    })
+    .or(EmptyStringToUndefined)
+    .optional(),
+  city: z
+    .string()
+    .max(255, { message: "City too long" })
+    .or(EmptyStringToUndefined)
+    .optional(),
+  // Only used in the `sfOnly` location input mode.
+  sfResident: z.boolean(),
+  message: z
+    .string()
+    .min(10, { message: "Message must be at least 10 characters" })
+    .max(10_000, { message: "Please limit message to 10,000 characters" }),
+});
+
+export function makePetitionFormSchema(locationInputMode: LocationInputMode) {
+  return PetitionFormObject.superRefine((data, ctx) => {
+    if (locationInputMode === "sfOnly") {
+      if (!data.sfResident) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "You must be a resident of San Francisco, CA to sign.",
+          path: ["sfResident"],
+        });
+      }
+      return;
+    }
+
+    // zipWithSonomaCountyCity mode:
     // If outside of US, throw away the zip code.
     if (data.outsideUS) {
       data.zip = undefined;
@@ -74,5 +104,53 @@ export const PetitionFormSchema = z
       });
     }
   });
+}
 
-export type PetitionForm = z.infer<typeof PetitionFormSchema>;
+export type PetitionForm = z.infer<typeof PetitionFormObject>;
+
+// Location submitted for signers in the `sfOnly` location input mode.
+const SAN_FRANCISCO_LOCATION = {
+  city: "san francisco",
+  state: "ca",
+  country: "us",
+} as const;
+
+/** Form fields the location resolvers derive a signer's location from. */
+type LocationInputData = Pick<PetitionForm, "zip" | "city" | "outsideUS">;
+
+/** Location values for a signer, resolved from their input mode. */
+export type ResolvedLocation = {
+  zip?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  outsideUS: boolean;
+};
+
+/**
+ * Source of truth for how each {@link LocationInputMode} turns signer
+ * input into a location.
+ */
+const LOCATION_RESOLVERS: Record<
+  LocationInputMode,
+  (data: LocationInputData) => ResolvedLocation
+> = {
+  sfOnly: () => ({
+    ...SAN_FRANCISCO_LOCATION,
+    outsideUS: false,
+  }),
+  zipWithSonomaCountyCity: (data) => ({
+    ...(data.zip && { zip: data.zip }),
+    ...(data.city && { city: data.city }),
+    ...(!data.outsideUS && { country: "United States" }),
+    outsideUS: data.outsideUS,
+  }),
+};
+
+/** Resolves the location values for the given input mode. */
+export function resolveLocation(
+  mode: LocationInputMode,
+  data: LocationInputData,
+): ResolvedLocation {
+  return LOCATION_RESOLVERS[mode](data);
+}

--- a/packages/email-petition/src/email-petition.tsx
+++ b/packages/email-petition/src/email-petition.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { PetitionForm, PetitionFormSchema } from "./data/petition";
+import {
+  LOCATION_INPUT_MODES,
+  LocationInputMode,
+  PetitionForm,
+  makePetitionFormSchema,
+  resolveLocation,
+} from "./data/petition";
+export type { LocationInputMode } from "./data/petition";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -48,6 +55,7 @@ export function EmailPetition(props: {
   petitionId: string;
   campaignName: string;
   defaultMessage: string;
+  locationInputMode: LocationInputMode;
   onSubmit?: () => void;
   debug: boolean;
   test: boolean;
@@ -55,6 +63,12 @@ export function EmailPetition(props: {
     defaultGoal: number;
   };
 }) {
+  if (!LOCATION_INPUT_MODES.includes(props.locationInputMode)) {
+    throw new Error(
+      `Invalid location-input-mode "${props.locationInputMode}". Must be one of: ${LOCATION_INPUT_MODES.join(", ")}.`,
+    );
+  }
+
   let petitionId = props.petitionId;
   let campaignName = props.campaignName;
   if (props.test) {
@@ -78,7 +92,7 @@ export function EmailPetition(props: {
   });
 
   const form = useForm<PetitionForm>({
-    resolver: zodResolver(PetitionFormSchema),
+    resolver: zodResolver(makePetitionFormSchema(props.locationInputMode)),
     defaultValues: {
       name: "",
       email: "",
@@ -86,6 +100,7 @@ export function EmailPetition(props: {
       outsideUS: false,
       zip: "",
       city: "",
+      sfResident: false,
       message: props.defaultMessage,
     },
   });
@@ -121,10 +136,12 @@ export function EmailPetition(props: {
           return;
         }
 
+        const location = resolveLocation(props.locationInputMode, data);
+
         const message = injectMessageValues(
           data.message,
           data.name,
-          data.city,
+          location.city ?? "",
           false,
         );
 
@@ -138,9 +155,10 @@ export function EmailPetition(props: {
               name: data.name,
               email: data.email,
               ...(data.phone && { phone: data.phone }),
-              ...(data.zip && { zip: data.zip }),
-              ...(data.city && { city: data.city }),
-              ...(!data.outsideUS && { country: "United States" }),
+              ...(location.zip && { zip: location.zip }),
+              ...(location.city && { city: location.city }),
+              ...(location.state && { state: location.state }),
+              ...(location.country && { country: location.country }),
               fullHref: window.location.href,
             }),
             headers: {
@@ -162,9 +180,11 @@ export function EmailPetition(props: {
               name: data.name,
               email: data.email,
               ...(data.phone && { phone: data.phone }),
-              outside_us: data.outsideUS,
-              ...(data.zip && { zip: data.zip }),
-              ...(data.city && { city: data.city }),
+              outside_us: location.outsideUS,
+              ...(location.zip && { zip: location.zip }),
+              ...(location.city && { city: location.city }),
+              ...(location.state && { state: location.state }),
+              ...(location.country && { country: location.country }),
               message: message,
               campaign: campaignName,
               token,
@@ -184,11 +204,18 @@ export function EmailPetition(props: {
         setIsSubmitting(false);
         recaptchaRef.current?.reset();
       }),
-    [handleSubmit],
+    [
+      handleSubmit,
+      props.locationInputMode,
+      props.onSubmit,
+      petitionId,
+      campaignName,
+    ],
   );
 
   const outsideUS = watch("outsideUS");
   const zip = watch("zip");
+  const city = watch("city");
   const isInSonomaCounty = useMemo(() => {
     return zip && zip in SonomaCities;
   }, [zip]);
@@ -255,6 +282,27 @@ export function EmailPetition(props: {
     [dirtyFields.message, resetField],
   );
 
+  // City injected into the visible message template ("" keeps the placeholder).
+  const getMessageCity = () =>
+    resolveLocation(props.locationInputMode, getValues()).city ?? "";
+
+  // Seed the visible message with relevant details so the signer sees the final
+  // text to send instead of placeholders.
+  useEffect(() => {
+    injectValuesIntoMessage(getValues("name"), getMessageCity());
+    // getMessageCity is recreated each render; the inputs it reads
+    // (locationInputMode + the zip/city/outsideUS fields resolveLocation
+    // derives from, and getValues) are the real dependencies.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    props.locationInputMode,
+    zip,
+    city,
+    outsideUS,
+    injectValuesIntoMessage,
+    getValues,
+  ]);
+
   const recaptchaRef = useRef<ReCAPTCHA>(null);
 
   // The reCAPTCHA widget is portaled into the document body (see below) rather
@@ -296,7 +344,7 @@ export function EmailPetition(props: {
                       {...field}
                       onBlur={() => {
                         field.onBlur();
-                        injectValuesIntoMessage(field.value, getValues("city"));
+                        injectValuesIntoMessage(field.value, getMessageCity());
                       }}
                     />
                   </FormControl>
@@ -336,95 +384,123 @@ export function EmailPetition(props: {
                 </FormItem>
               )}
             />
-            <FormField
-              control={control}
-              name="zip"
-              disabled={outsideUS || isSubmitting}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    Zip Code <span className="font-normal">(US only)</span>
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      type="text"
-                      placeholder={
-                        outsideUS ? "United States zip codes only" : "95401"
-                      }
-                      {...field}
-                      onBlur={() => {
-                        field.onBlur();
-                        injectValuesIntoMessage(
-                          getValues("name"),
-                          getValues("city"),
-                        );
-                      }}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={control}
-              name="city"
-              disabled={outsideUS || isSubmitting}
-              render={({ field }) => (
-                <FormItem className={cn({ hidden: !cities.length })}>
-                  <FormLabel>City</FormLabel>
-                  <Select
-                    onValueChange={(val: string | undefined) => {
-                      field.onChange(val);
-                      injectValuesIntoMessage(getValues("name"), val);
-                    }}
-                    defaultValue={field.value}
-                    value={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a city" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {cities?.map((city) => (
-                        <SelectItem
-                          value={city}
-                          key={city}
-                          onBlur={field.onBlur}
-                        >
-                          {city}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={control}
-              name="outsideUS"
-              disabled={isSubmitting}
-              render={({ field }) => (
-                <FormItem
-                  className={cn("flex gap-2 items-center", {
-                    hidden: cities.length,
-                  })}
-                >
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                      aria-label="Outside the United States?"
-                    />
-                  </FormControl>
-                  <FormLabel className="mt-0!">
-                    Outside the United States
-                  </FormLabel>
-                  <FormDescription></FormDescription>
-                </FormItem>
-              )}
-            />
+            {props.locationInputMode === "zipWithSonomaCountyCity" && (
+              <>
+                <FormField
+                  control={control}
+                  name="zip"
+                  disabled={outsideUS || isSubmitting}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        Zip Code <span className="font-normal">(US only)</span>
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          type="text"
+                          placeholder={
+                            outsideUS ? "United States zip codes only" : "95401"
+                          }
+                          {...field}
+                          onBlur={() => {
+                            field.onBlur();
+                            injectValuesIntoMessage(
+                              getValues("name"),
+                              getValues("city"),
+                            );
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={control}
+                  name="city"
+                  disabled={outsideUS || isSubmitting}
+                  render={({ field }) => (
+                    <FormItem className={cn({ hidden: !cities.length })}>
+                      <FormLabel>City</FormLabel>
+                      <Select
+                        onValueChange={(val: string | undefined) => {
+                          field.onChange(val);
+                          injectValuesIntoMessage(getValues("name"), val);
+                        }}
+                        defaultValue={field.value}
+                        value={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a city" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {cities?.map((city) => (
+                            <SelectItem
+                              value={city}
+                              key={city}
+                              onBlur={field.onBlur}
+                            >
+                              {city}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={control}
+                  name="outsideUS"
+                  disabled={isSubmitting}
+                  render={({ field }) => (
+                    <FormItem
+                      className={cn("flex gap-2 items-center", {
+                        hidden: cities.length,
+                      })}
+                    >
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                          aria-label="Outside the United States?"
+                        />
+                      </FormControl>
+                      <FormLabel className="mt-0!">
+                        Outside the United States
+                      </FormLabel>
+                      <FormDescription></FormDescription>
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
+            {props.locationInputMode === "sfOnly" && (
+              <FormField
+                control={control}
+                name="sfResident"
+                disabled={isSubmitting}
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex gap-2 items-center">
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                          aria-label="I am a resident of San Francisco, CA"
+                        />
+                      </FormControl>
+                      <FormLabel className="mt-0!">
+                        I am a resident of San Francisco, CA
+                      </FormLabel>
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
           </div>
           <div className="flex flex-col gap-4 basis-2/3">
             <FormField


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `location-input-mode` option to petition forms, supporting `zipWithSonomaCountyCity` and a San Francisco–only mode (`sfOnly`).
  * Updated petition pages and previews to default to `zipWithSonomaCountyCity`, and added an `sfOnly` dev-preview page.
* **Bug Fixes**
  * Improved validation and submission so location details are derived from the selected mode and only the relevant inputs are shown.
* **Documentation**
  * Expanded the web component README with the new required attribute, accepted values, and updated examples (including `sfOnly`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->